### PR TITLE
feat: Update wizard to 0.42.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
         "npm": ">=10.0.0"
       },
       "optionalDependencies": {
-        "@seamapi/wizard": "^0.38.1"
+        "@seamapi/wizard": "^0.42.0"
       }
     },
     "node_modules/@alcalzone/ansi-tokenize": {
@@ -3750,9 +3750,9 @@
       }
     },
     "node_modules/@seamapi/wizard": {
-      "version": "0.38.1",
-      "resolved": "https://registry.npmjs.org/@seamapi/wizard/-/wizard-0.38.1.tgz",
-      "integrity": "sha512-XmevgpJmiSHGrBLV0Hiz2/87VmVZKXSkL5vO4OqK9v6QrdxzJE7WwEJ8GdM7ZKYeI0o78L/dJbJKLd1Lm5bRrg==",
+      "version": "0.42.0",
+      "resolved": "https://registry.npmjs.org/@seamapi/wizard/-/wizard-0.42.0.tgz",
+      "integrity": "sha512-RIF1oTMowC/E5LfffZ/49Wiiw5wF1TjT4NmEF3HRz1Q1JhWL4/vAEtmRJFQr9OlnW2wKIZ0V7lKz6/EAX4N97g==",
       "license": "MIT",
       "optional": true,
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
   },
   "packageManager": "npm@11.19.0",
   "optionalDependencies": {
-    "@seamapi/wizard": "^0.38.1"
+    "@seamapi/wizard": "^0.42.0"
   },
   "dependencies": {
     "@clack/prompts": "^1.7.0",


### PR DESCRIPTION
## Problem

`@seamapi/cli` declares the wizard as an optional dependency:

```json
"optionalDependencies": {
  "@seamapi/wizard": "^0.38.1"
}
```

npm's caret operator only permits **patch-level** changes for versions below `1.0.0`, so `^0.38.1` resolves to `>=0.38.1 <0.39.0`.

`@seamapi/wizard` is published at **0.42.0**, which falls outside that range. Anyone running `npx @seamapi/cli wizard` gets a wizard four minor versions stale, and no warning is printed.

## Fix

Move the range to `^0.42.0` and refresh the lockfile — the same shape as #637 (`^0.28.0` → `^0.38.1`).

The dependency stays **optional**, which is deliberate: packaging sources that disallow non-commercial licenses (the Claude SDK) omit it, and `runWizard` already handles that with a dedicated `UsageError`.

## Lockfile note for reviewers

The lockfile diff is deliberately minimal — 5 insertions, 5 deletions: the range, plus the wizard's `version` / `resolved` / `integrity`. No other entry is added or removed.

Two traps worth recording, since both silently produce a lockfile that breaks CI:

1. **Registry.** A contributor with `@seamapi:registry=https://npm.pkg.github.com/` in `~/.npmrc` (common for Seam employees) gets a lockfile whose wizard `resolved` URL points at GitHub Packages. CI's `npm ci` cannot authenticate there, and because the dependency is *optional* the failure is swallowed — surfacing later as `TS2307: Cannot find module '@seamapi/wizard'` rather than an install error. Regenerate with `--@seamapi:registry=https://registry.npmjs.org/`.
2. **npm version.** Regenerating with an npm older than the pinned `packageManager` (`npm@11.19.0`) drops the wizard's optional *peer* subtree — `ink`, `react`, `@anthropic-ai/sdk`, `@modelcontextprotocol/sdk`, `express`, `hono` — 11 entries in total.

This branch was regenerated with `npm@11.19.0` against the public registry, and its package set is identical to `main`'s.

## Verification

- `npm ci` with GitHub auth removed installs the wizard at 0.42.0 with `ink`/`react` present.
- `npm run typecheck` — clean, on Node 22 and 24 in CI.
- `npm run lint` — clean, Prettier included.
- Full CI green.

## Follow-up worth considering

Because a caret cannot cross a minor below `1.0.0`, this range goes stale again on the wizard's next minor release. Options: widen to `>=0.38.1 <1`, or add an explicit Dependabot rule so the bump is automated rather than manual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)